### PR TITLE
구조변경

### DIFF
--- a/src/main/java/com/eglowc/boot_blog/common/ErrorInfos.java
+++ b/src/main/java/com/eglowc/boot_blog/common/ErrorInfos.java
@@ -13,6 +13,8 @@ import java.util.List;
 
 /**
  * Created by hclee on 2016-05-11.
+ *
+ * @author eglowc
  */
 @Data
 public class ErrorInfos {
@@ -39,9 +41,9 @@ public class ErrorInfos {
     /**
      * Valid FieldError 를 처리함
      *
-     * @param errorMessage
-     * @param errorCode
-     * @param fieldErrors
+     * @param errorMessage 에러 메시지
+     * @param errorCode    에러 코드
+     * @param fieldErrors  필드 검증에러
      */
     public ErrorInfos(String errorMessage, String errorCode, List<FieldError> fieldErrors) {
         this.errorMessage = errorMessage;
@@ -49,15 +51,17 @@ public class ErrorInfos {
 
         if (fieldErrors != null) {
             this.fieldErrors = new ArrayList<>();
-            fieldErrors.forEach(e -> this.fieldErrors.add(new FieldErrorInfo(e.getField(), e.getRejectedValue().toString(), e.getDefaultMessage())));
+            fieldErrors.forEach(e -> this.fieldErrors
+                            .add(new FieldErrorInfo(e.getField(), String.valueOf(e.getRejectedValue()), e.getDefaultMessage()))
+            );
         }
     }
 
     /**
      * Valid FieldError 처리안함
      *
-     * @param errorMessage
-     * @param errorCode
+     * @param errorMessage 에러 메시지
+     * @param errorCode    에러 코드
      */
     public ErrorInfos(String errorMessage, String errorCode) {
         this(errorMessage, errorCode, null);

--- a/src/main/java/com/eglowc/boot_blog/common/exception/UserDuplicatedException.java
+++ b/src/main/java/com/eglowc/boot_blog/common/exception/UserDuplicatedException.java
@@ -7,6 +7,10 @@ import lombok.Getter;
 
 /**
  * Created by hclee on 2016-05-11.
+ * <p/>
+ * 사용자 추가시 중복된 사용자이름 발생으로 인한 예외
+ *
+ * @author eglowc
  */
 @AllArgsConstructor
 public class UserDuplicatedException extends RuntimeException {

--- a/src/main/java/com/eglowc/boot_blog/common/exception/UserDuplicatedException.java
+++ b/src/main/java/com/eglowc/boot_blog/common/exception/UserDuplicatedException.java
@@ -1,4 +1,4 @@
-package com.eglowc.boot_blog.accounts;
+package com.eglowc.boot_blog.common.exception;
 
 
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/eglowc/boot_blog/common/utilities/ResponseEntityUtil.java
+++ b/src/main/java/com/eglowc/boot_blog/common/utilities/ResponseEntityUtil.java
@@ -7,8 +7,10 @@ import org.springframework.http.ResponseEntity;
 
 /**
  * Created by hclee on 2016-05-12.
+ *
+ * @author eglowc
  */
-
+@Deprecated
 public class ResponseEntityUtil<T> {
 
     @Data

--- a/src/main/java/com/eglowc/boot_blog/domain/User.java
+++ b/src/main/java/com/eglowc/boot_blog/domain/User.java
@@ -1,4 +1,4 @@
-package com.eglowc.boot_blog.accounts.domain;
+package com.eglowc.boot_blog.domain;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Data;

--- a/src/main/java/com/eglowc/boot_blog/domain/User.java
+++ b/src/main/java/com/eglowc/boot_blog/domain/User.java
@@ -1,13 +1,22 @@
 package com.eglowc.boot_blog.domain;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
+import org.hibernate.validator.constraints.Email;
+import org.hibernate.validator.constraints.NotBlank;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.validation.constraints.Size;
 import java.util.Date;
 
 /**
  * Created by hclee on 2016-05-11.
+ *
+ * @author eglowc
  */
 @Entity
 @Data
@@ -17,21 +26,26 @@ public class User {
     @GeneratedValue
     private long id;
 
-    @Column(unique = true)
+    @Column(unique = true, length = 50)
+    @NotBlank
+    @Size(min = 5, max = 50)
     private String userName;
 
+    @NotBlank
+    @Email
     private String userEmail;
 
     private String userNickName;
 
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    @NotBlank
+    @Size(min = 9, max = 50)
     private String password;
 
-//    @Temporal(TemporalType.TIMESTAMP)
-    @JsonFormat(pattern="yyyy-MM-dd HH:MM:ss")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:MM:ss")
     private Date joined;
 
-//    @Temporal(TemporalType.TIMESTAMP)
-    @JsonFormat(pattern="yyyy-MM-dd HH:MM:ss")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:MM:ss")
     private Date updated;
 
 }

--- a/src/main/java/com/eglowc/boot_blog/dto/UserDto.java
+++ b/src/main/java/com/eglowc/boot_blog/dto/UserDto.java
@@ -10,6 +10,8 @@ import java.util.Date;
 
 /**
  * Created by hclee on 2016-05-11.
+ *
+ * @author eglowc
  */
 public class UserDto {
 
@@ -38,9 +40,9 @@ public class UserDto {
         private String userName;
         private String userEmail;
         private String userNickName;
-        @JsonFormat(pattern="yyyy-MM-dd HH:MM:ss")
+        @JsonFormat(pattern = "yyyy-MM-dd HH:MM:ss")
         private Date joined;
-        @JsonFormat(pattern="yyyy-MM-dd HH:MM:ss")
+        @JsonFormat(pattern = "yyyy-MM-dd HH:MM:ss")
         private Date updated;
 
     }

--- a/src/main/java/com/eglowc/boot_blog/dto/UserDto.java
+++ b/src/main/java/com/eglowc/boot_blog/dto/UserDto.java
@@ -1,4 +1,4 @@
-package com.eglowc.boot_blog.accounts;
+package com.eglowc.boot_blog.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Data;

--- a/src/main/java/com/eglowc/boot_blog/repository/UserRepository.java
+++ b/src/main/java/com/eglowc/boot_blog/repository/UserRepository.java
@@ -1,6 +1,6 @@
-package com.eglowc.boot_blog.accounts;
+package com.eglowc.boot_blog.repository;
 
-import com.eglowc.boot_blog.accounts.domain.User;
+import com.eglowc.boot_blog.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;

--- a/src/main/java/com/eglowc/boot_blog/repository/UserRepository.java
+++ b/src/main/java/com/eglowc/boot_blog/repository/UserRepository.java
@@ -7,6 +7,8 @@ import java.util.List;
 
 /**
  * Created by hclee on 2016-05-11.
+ *
+ * @author eglowc
  */
 public interface UserRepository extends JpaRepository<User, Long> {
 

--- a/src/main/java/com/eglowc/boot_blog/service/UserService.java
+++ b/src/main/java/com/eglowc/boot_blog/service/UserService.java
@@ -1,9 +1,9 @@
-package com.eglowc.boot_blog.accounts.service;
+package com.eglowc.boot_blog.service;
 
-import com.eglowc.boot_blog.accounts.UserDto;
-import com.eglowc.boot_blog.accounts.UserDuplicatedException;
-import com.eglowc.boot_blog.accounts.UserRepository;
-import com.eglowc.boot_blog.accounts.domain.User;
+import com.eglowc.boot_blog.common.exception.UserDuplicatedException;
+import com.eglowc.boot_blog.domain.User;
+import com.eglowc.boot_blog.dto.UserDto;
+import com.eglowc.boot_blog.repository.UserRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,18 +26,16 @@ public class UserService {
     @Autowired
     private ModelMapper modelMapper;
 
-    public User createUser(UserDto.Create dto) {
-
-        User user = modelMapper.map(dto, User.class);
-
-        String userName = dto.getUserName();
+    public User createUser(final UserDto.Create dto) {
+        final User user = modelMapper.map(dto, User.class);
+        final String userName = dto.getUserName();
 
         if (userRepository.findByUserName(userName) != null) {
             log.error("user duplicated exception. {}", userName);
             throw new UserDuplicatedException(userName);
         }
 
-        Date now = new Date();
+        final Date now = new Date();
         user.setJoined(now);
         user.setUpdated(now);
 

--- a/src/main/java/com/eglowc/boot_blog/service/UserService.java
+++ b/src/main/java/com/eglowc/boot_blog/service/UserService.java
@@ -2,10 +2,8 @@ package com.eglowc.boot_blog.service;
 
 import com.eglowc.boot_blog.common.exception.UserDuplicatedException;
 import com.eglowc.boot_blog.domain.User;
-import com.eglowc.boot_blog.dto.UserDto;
 import com.eglowc.boot_blog.repository.UserRepository;
 import lombok.extern.slf4j.Slf4j;
-import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,6 +12,8 @@ import java.util.Date;
 
 /**
  * Created by hclee on 2016-05-11.
+ *
+ * @author eglowc
  */
 @Service
 @Transactional
@@ -23,12 +23,8 @@ public class UserService {
     @Autowired
     private UserRepository userRepository;
 
-    @Autowired
-    private ModelMapper modelMapper;
-
-    public User createUser(final UserDto.Create dto) {
-        final User user = modelMapper.map(dto, User.class);
-        final String userName = dto.getUserName();
+    public User createUser(final User user) {
+        final String userName = user.getUserName();
 
         if (userRepository.findByUserName(userName) != null) {
             log.error("user duplicated exception. {}", userName);

--- a/src/main/java/com/eglowc/boot_blog/web/UserController.java
+++ b/src/main/java/com/eglowc/boot_blog/web/UserController.java
@@ -1,9 +1,9 @@
-package com.eglowc.boot_blog.accounts.web;
+package com.eglowc.boot_blog.web;
 
-import com.eglowc.boot_blog.accounts.UserDto;
-import com.eglowc.boot_blog.accounts.UserDuplicatedException;
-import com.eglowc.boot_blog.accounts.domain.User;
-import com.eglowc.boot_blog.accounts.service.UserService;
+import com.eglowc.boot_blog.dto.UserDto;
+import com.eglowc.boot_blog.common.exception.UserDuplicatedException;
+import com.eglowc.boot_blog.domain.User;
+import com.eglowc.boot_blog.service.UserService;
 import com.eglowc.boot_blog.common.ErrorInfos;
 import com.eglowc.boot_blog.common.utilities.ResponseEntityUtil;
 import lombok.extern.slf4j.Slf4j;
@@ -58,11 +58,11 @@ public class UserController {
      * @return
      */
     @RequestMapping(method = PUT)
-    public ResponseEntity createUser(@RequestBody @Valid UserDto.Create create,
+    public ResponseEntity createUser(@RequestBody @Valid final UserDto.Create create,
                                      BindingResult result) {
 
         if (result.hasErrors()) {
-            ErrorInfos errorInfos = new ErrorInfos(
+            final ErrorInfos errorInfos = new ErrorInfos(
                     "잘못된 요청입니다.",
                     "bad.request",
                     result.getFieldErrors()
@@ -71,7 +71,7 @@ public class UserController {
             return entityUtil.getResponse(errorInfos, false, HttpStatus.BAD_REQUEST);
         }
 
-        User createdUser = userService.createUser(create);
+        final User createdUser = userService.createUser(create);
 
         return entityUtil.getSuccess(modelMapper.map(createdUser, User.class), HttpStatus.CREATED);
     }

--- a/src/main/java/com/eglowc/boot_blog/web/UserController.java
+++ b/src/main/java/com/eglowc/boot_blog/web/UserController.java
@@ -1,13 +1,10 @@
 package com.eglowc.boot_blog.web;
 
-import com.eglowc.boot_blog.dto.UserDto;
+import com.eglowc.boot_blog.common.ErrorInfos;
 import com.eglowc.boot_blog.common.exception.UserDuplicatedException;
 import com.eglowc.boot_blog.domain.User;
 import com.eglowc.boot_blog.service.UserService;
-import com.eglowc.boot_blog.common.ErrorInfos;
-import com.eglowc.boot_blog.common.utilities.ResponseEntityUtil;
 import lombok.extern.slf4j.Slf4j;
-import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,11 +16,14 @@ import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
 
-import static org.springframework.web.bind.annotation.RequestMethod.*;
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+import static org.springframework.web.bind.annotation.RequestMethod.PUT;
 
 
 /**
  * Created by hclee on 2016-05-11.
+ *
+ * @author eglowc
  */
 @Slf4j
 @RestController
@@ -31,34 +31,28 @@ import static org.springframework.web.bind.annotation.RequestMethod.*;
 public class UserController {
 
     @Autowired
-    private ModelMapper modelMapper;
-
-    @Autowired
-    private ResponseEntityUtil entityUtil;
-
-    @Autowired
     private UserService userService;
 
     /**
      * User List
      *
-     * @return
+     * @return 200 OK
      */
     @RequestMapping(method = GET)
     public ResponseEntity users() {
-        String message = "Hello Libo.accounts";
+        String message = "Hello. accounts";
         return new ResponseEntity<>(message, HttpStatus.OK);
     }
 
     /**
      * create User
      *
-     * @param create
-     * @param result
-     * @return
+     * @param user   새롭게 생성할 {@link User} 정보
+     * @param result {@link BindingResult}
+     * @return {@link ResponseEntity}
      */
     @RequestMapping(method = PUT)
-    public ResponseEntity createUser(@RequestBody @Valid final UserDto.Create create,
+    public ResponseEntity createUser(@RequestBody @Valid final User user,
                                      BindingResult result) {
 
         if (result.hasErrors()) {
@@ -68,27 +62,26 @@ public class UserController {
                     result.getFieldErrors()
             );
 
-            return entityUtil.getResponse(errorInfos, false, HttpStatus.BAD_REQUEST);
+            return new ResponseEntity<>(errorInfos, HttpStatus.BAD_REQUEST);
         }
 
-        final User createdUser = userService.createUser(create);
-
-        return entityUtil.getSuccess(modelMapper.map(createdUser, User.class), HttpStatus.CREATED);
+        return new ResponseEntity<>(userService.createUser(user), HttpStatus.CREATED);
     }
 
     /**
      * 사용자 생성시 중복된 userName 을 사용한 경우 예외처리.
      *
-     * @param
-     * @return
+     * @param e {@link UserDuplicatedException}
+     * @return {@link ErrorInfos}
      */
     @ExceptionHandler(UserDuplicatedException.class)
     public ResponseEntity handleUserDuplicatedException(UserDuplicatedException e) {
         ErrorInfos errorInfos = new ErrorInfos(
-                "[" + e.getUserName().toString() + "] 중복된 username 입니다.",
+                "[" + e.getUserName() + "] 중복된 username 입니다.",
                 "users.username.duplicated"
         );
-        return entityUtil.getFail(errorInfos, HttpStatus.EXPECTATION_FAILED);
+
+        return new ResponseEntity<>(errorInfos, HttpStatus.EXPECTATION_FAILED);
     }
 
 }

--- a/src/test/java/com/eglowc/boot_blog/blog/ApplicationTests.java
+++ b/src/test/java/com/eglowc/boot_blog/blog/ApplicationTests.java
@@ -10,7 +10,7 @@ import org.springframework.test.context.web.WebAppConfiguration;
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = Application.class)
 @WebAppConfiguration
-public class LiboApplicationTests {
+public class ApplicationTests {
 
 	@Test
 	public void contextLoads() {


### PR DESCRIPTION
# package 구조를 기존의 익숙한 방식으로 변경

# api 응답 포맷을 단순화
  - ResponseEntityUtil 을 이용해서 기본적인 정보외에 추가적인 정보를 담으려고 했지만, 불필요하고 보기에 좋지 않아보여서 제거하였음.
  - api의 성공과 실패등은 HttpStatus로 분기하도록 하고 api문서 작성시에 각 상태에대한 설명을 작성하는 것으로 계획

# dto 제거
  - dto 를 만들어서 사용하는 것도 작업량을 증대시키는 것으로 판단
  - 복잡한 json serialize/deserialize 는 https://github.com/FasterXML/jackson-annotations 를 사용해서 작성하도록 노력